### PR TITLE
fix problem with uri parsing

### DIFF
--- a/ming/datastore.py
+++ b/ming/datastore.py
@@ -2,9 +2,9 @@
 from __future__ import with_statement
 import time
 import logging
-import urllib.parse
 
 import six
+from six.moves import urllib
 from threading import Lock
 
 from pymongo import MongoClient

--- a/ming/datastore.py
+++ b/ming/datastore.py
@@ -2,7 +2,6 @@
 from __future__ import with_statement
 import time
 import logging
-
 import six
 from six.moves import urllib
 from threading import Lock

--- a/ming/datastore.py
+++ b/ming/datastore.py
@@ -62,10 +62,10 @@ def create_datastore(uri, **kwargs):
             (kwargs.keys(),))
 
     try:
-        parts = parse_uri(uri)
+        database = parse_uri(uri)["database"]
     except InvalidURI:
         urlparts = urllib.parse.urlsplit(uri)
-        parts = {"database": urlparts.path}
+        database = urlparts.path
         # Create the engine (if necessary)
         if urlparts.scheme:
             if bind:
@@ -73,7 +73,6 @@ def create_datastore(uri, **kwargs):
             bind = create_engine(uri, **kwargs)
 
     # extract the database
-    database = parts.get("database")
     if database.startswith("/"):
         database = database[1:]
 

--- a/ming/tests/test_datastore.py
+++ b/ming/tests/test_datastore.py
@@ -186,6 +186,12 @@ class TestDatastore(TestCase):
         conn = ds.bind.connect()
         assert conn is mim.Connection.get()
 
+    def test_create_datastore_bind_not_allowed(self):
+        self.assertRaises(
+            ming.exc.MingConfigError,
+            create_datastore,
+            'mim://test_db', bind=create_engine('master'))
+
     def _check_datastore(self, ds, db_name):
         assert ds.db is self.MockConn()[db_name]
         assert ds.name == db_name


### PR DESCRIPTION
Due to https://bugs.python.org/issue18140, if the URI contains special characters the connection will fail on `ming.datastore.create_datastore`. Using pymongo's own uri `parse_uri` function fixes the problem.