### PR TITLE
Add initial support to Decimal128

### DIFF
--- a/ming/base.py
+++ b/ming/base.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import bson
 import six
+from bson import Decimal128
 
 from ming.exc import MingException
 
@@ -144,7 +145,7 @@ def _safe_bson(obj):
             bson.ObjectId)):
         return obj
     elif isinstance(obj, decimal.Decimal):
-        return float(obj)
+        return Decimal128(obj)
     else:
         assert False, '%s is not safe for bsonification: %r' % (
             type(obj), obj)

--- a/ming/base.py
+++ b/ming/base.py
@@ -1,6 +1,7 @@
 """Ming Base module.  Good stuff here.
 """
 import decimal
+import warnings
 from collections import defaultdict
 from datetime import datetime
 
@@ -53,6 +54,9 @@ class Object(dict):
             return bson
 
     def make_safe(self):
+        warnings.warn("make_safe is now deprecated. "
+                      "If your code relies on make_safe for validation, "
+                      "you should consider adding your own layer of validation", DeprecationWarning)
         safe_self = _safe_bson(self)
         self.update(safe_self)
 
@@ -132,14 +136,18 @@ class Cursor(object):
         return self
 
 NoneType = type(None)
-def _safe_bson(obj):
+def _safe_bson(obj, _no_warning=False):
     '''Verify that the obj is safe for bsonification (in particular, no tuples or
     Decimal objects
     '''
+    if not _no_warning:
+        warnings.warn("_safe_bson is now deprecated. "
+                      "If your code relies on _safe_bson for validation, "
+                      "you should consider adding your own layer of validation", DeprecationWarning)
     if isinstance(obj, list):
-        return [ _safe_bson(o) for o in obj ]
+        return [ _safe_bson(o, True) for o in obj ]
     elif isinstance(obj, dict):
-        return Object((k, _safe_bson(v)) for k,v in six.iteritems(obj))
+        return Object((k, _safe_bson(v, True)) for k,v in six.iteritems(obj))
     elif isinstance(obj, six.string_types + six.integer_types + (
             float, datetime, NoneType,
             bson.ObjectId)):

--- a/ming/schema.py
+++ b/ming/schema.py
@@ -741,8 +741,6 @@ class NumberDecimal(ParticularScalar):
 
     def _validate(self, value, **kw):
         value = super(NumberDecimal, self)._validate(value, **kw)
-        if value is None:
-            return
         if isinstance(value, Decimal128):
             value = value.to_decimal()
         elif not isinstance(value, Decimal):

--- a/ming/schema.py
+++ b/ming/schema.py
@@ -736,7 +736,7 @@ class NumberDecimal(ParticularScalar):
     ):
         super(NumberDecimal, self).__init__(**kwargs)
         self.precision = precision
-        self._quantizing = Decimal(f".{'0' * (self.precision - 1)}1")
+        self._quantizing = Decimal("." + "0" * (self.precision - 1) + "1")
         self.rounding = rounding
 
     def _validate(self, value, **kw):

--- a/ming/schema.py
+++ b/ming/schema.py
@@ -3,11 +3,13 @@ import logging
 
 from copy import deepcopy
 from datetime import datetime, date
+from decimal import Decimal, ROUND_HALF_DOWN
 
 import bson
 import pymongo
 import pytz
 import six
+from bson import Decimal128
 
 from .utils import LazyProperty
 from .base import Object as BaseObject, Missing, NoDefault
@@ -708,10 +710,52 @@ class ObjectId(Scalar):
         except Exception as ex:
             raise Invalid(str(ex), value, None)
 
+
+class NumberDecimal(ParticularScalar):
+    """Validates value is compatible with :class:`bson.Decimal128`.
+
+    Useful for financial data that need arbitrary precision.
+
+    The argument `precision` specifies the number of decimal digits to evaluate.
+    Defaults to 6.
+
+    The argument `rounding` specifies the kind of rounding to be performed.
+    Valid values are `decimal.ROUND_DOWN`, `decimal.ROUND_HALF_UP`, `decimal.ROUND_HALF_EVEN`,
+    `decimal.ROUND_CEILING`, `decimal.ROUND_FLOOR`, `decimal.ROUND_UP`,
+    `decimal.ROUND_HALF_DOWN`, `decimal.ROUND_05UP`.
+    Defaults to `decimal.ROUND_HALF_DOWN`.
+
+    """
+    type = (int, float, Decimal, Decimal128)
+
+    def __init__(
+        self,
+        precision=6,
+        rounding=ROUND_HALF_DOWN,
+        **kwargs
+    ):
+        super(NumberDecimal, self).__init__(**kwargs)
+        self.precision = precision
+        self._quantizing = Decimal(f".{'0' * (self.precision - 1)}1")
+        self.rounding = rounding
+
+    def _validate(self, value, **kw):
+        value = super(NumberDecimal, self)._validate(value, **kw)
+        if value is None:
+            return
+        if isinstance(value, Decimal128):
+            value = value.to_decimal()
+        elif not isinstance(value, Decimal):
+            value = Decimal(value)
+        return Decimal128(value.quantize(self._quantizing, rounding=self.rounding))
+
+
 # Shorthand for various SchemaItems
-SHORTHAND={
-    int:Int,
-    str:String,
-    float:Float,
-    bool:Bool,
-    datetime:DateTime}
+SHORTHAND = {
+    int: Int,
+    str: String,
+    float: Float,
+    bool: Bool,
+    datetime: DateTime,
+    Decimal128: NumberDecimal,
+}

--- a/ming/session.py
+++ b/ming/session.py
@@ -144,7 +144,6 @@ class Session(object):
         hook = doc.m.before_save
         if hook: hook(doc)
         if validate:
-            doc.make_safe()
             if doc.m.schema is None:
                 data = dict(doc)
             else:
@@ -201,7 +200,6 @@ class Session(object):
         immediately
         """
         fields_values = Object.from_bson(fields_values)
-        fields_values.make_safe()
         for k,v in six.iteritems(fields_values):
             self._set(doc, k.split('.'), v)
         impl = self._impl(doc)

--- a/ming/tests/test_schema.py
+++ b/ming/tests/test_schema.py
@@ -168,13 +168,6 @@ class TestNumberDecimal(TestCase):
         si = S.NumberDecimal()
         assert si.validate(None) is None
 
-    def test_default_values(self):
-        si = S.NumberDecimal()
-        assert si.validate(0.123456789) == Decimal128("0.123457")
-        assert si.validate(0.123456789) != Decimal128("0.123456789")
-        assert si.validate(0.123456432) == Decimal128("0.123456")
-        assert si.validate(0.123456432) != Decimal128("0.123456432")
-
     def test_specify_precision(self):
         si = S.NumberDecimal(precision=2)
         assert si.validate(0.123456789) == Decimal128("0.12")
@@ -185,21 +178,38 @@ class TestNumberDecimal(TestCase):
         assert si.validate(0.129999999) == Decimal128("0.12")
         assert si.validate(0.123456789) == Decimal128("0.12")
 
-    def test_input_int(self):
+    def test_input_int_precision_explicit(self):
         si = S.NumberDecimal(precision=2)
         assert si.validate(0) == Decimal128("0.00")
         assert si.validate(1) == Decimal128("1.00")
 
-    def test_input_float(self):
+    def test_input_float_precision_explicit(self):
         si = S.NumberDecimal(precision=2)
         assert si.validate(12.42) == Decimal128("12.42")
 
-    def test_input_decimal(self):
+    def test_input_decimal_precision_explicit(self):
         si = S.NumberDecimal(precision=2)
         assert si.validate(Decimal("12.42")) == Decimal128("12.42")
 
-    def test_input_decimal128(self):
+    def test_input_decimal128_precision_explicit(self):
         si = S.NumberDecimal(precision=2)
+        assert si.validate(Decimal128("12.42")) == Decimal128("12.42")
+
+    def test_input_int(self):
+        si = S.NumberDecimal()
+        assert si.validate(0) == Decimal128("0")
+        assert si.validate(1) == Decimal128("1")
+
+    def test_input_float(self):
+        si = S.NumberDecimal()
+        assert si.validate(12.42) == Decimal128("12.42")
+
+    def test_input_decimal(self):
+        si = S.NumberDecimal()
+        assert si.validate(Decimal("12.42")) == Decimal128("12.42")
+
+    def test_input_decimal128(self):
+        si = S.NumberDecimal()
         assert si.validate(Decimal128("12.42")) == Decimal128("12.42")
 
     def test_input_str(self):

--- a/ming/tests/test_schema.py
+++ b/ming/tests/test_schema.py
@@ -1,4 +1,4 @@
-from decimal import Decimal, ROUND_DOWN
+from decimal import Decimal, ROUND_DOWN, ROUND_HALF_DOWN
 from unittest import TestCase, main
 from datetime import datetime, date
 
@@ -202,7 +202,11 @@ class TestNumberDecimal(TestCase):
 
     def test_input_float(self):
         si = S.NumberDecimal()
-        assert si.validate(12.42) == Decimal128("12.42")
+        validated = si.validate(12.42)
+        assert isinstance(validated, Decimal128)
+        quantized = validated.to_decimal().quantize(Decimal("0.01"),
+                                                    rounding=ROUND_HALF_DOWN)
+        assert quantized == Decimal("12.42")
 
     def test_input_decimal(self):
         si = S.NumberDecimal()

--- a/ming/tests/test_schema.py
+++ b/ming/tests/test_schema.py
@@ -164,6 +164,10 @@ class TestNumberDecimal(TestCase):
         si = S.NumberDecimal(allow_none=False)
         self.assertRaises(S.Invalid, si.validate, None)
 
+    def test_allow_none(self):
+        si = S.NumberDecimal()
+        assert si.validate(None) is None
+
     def test_default_values(self):
         si = S.NumberDecimal()
         assert si.validate(0.123456789) == Decimal128("0.123457")

--- a/ming/tests/test_schema.py
+++ b/ming/tests/test_schema.py
@@ -1,5 +1,8 @@
+from decimal import Decimal, ROUND_DOWN
 from unittest import TestCase, main
 from datetime import datetime, date
+
+from bson import Decimal128
 
 import ming.datastore
 import pytz
@@ -154,6 +157,51 @@ class TestSchemaItem(TestCase):
 
     def test_nodefault(self):
         self.assertEqual(repr(S.NoDefault), '<NoDefault>')
+
+
+class TestNumberDecimal(TestCase):
+    def test_dont_allow_none(self):
+        si = S.NumberDecimal(allow_none=False)
+        self.assertRaises(S.Invalid, si.validate, None)
+
+    def test_default_values(self):
+        si = S.NumberDecimal()
+        assert si.validate(0.123456789) == Decimal128("0.123457")
+        assert si.validate(0.123456789) != Decimal128("0.123456789")
+        assert si.validate(0.123456432) == Decimal128("0.123456")
+        assert si.validate(0.123456432) != Decimal128("0.123456432")
+
+    def test_specify_precision(self):
+        si = S.NumberDecimal(precision=2)
+        assert si.validate(0.123456789) == Decimal128("0.12")
+        assert si.validate(0.125432109) == Decimal128("0.13")
+
+    def test_specify_rounding(self):
+        si = S.NumberDecimal(precision=2, rounding=ROUND_DOWN)
+        assert si.validate(0.129999999) == Decimal128("0.12")
+        assert si.validate(0.123456789) == Decimal128("0.12")
+
+    def test_input_int(self):
+        si = S.NumberDecimal(precision=2)
+        assert si.validate(0) == Decimal128("0.00")
+        assert si.validate(1) == Decimal128("1.00")
+
+    def test_input_float(self):
+        si = S.NumberDecimal(precision=2)
+        assert si.validate(12.42) == Decimal128("12.42")
+
+    def test_input_decimal(self):
+        si = S.NumberDecimal(precision=2)
+        assert si.validate(Decimal("12.42")) == Decimal128("12.42")
+
+    def test_input_decimal128(self):
+        si = S.NumberDecimal(precision=2)
+        assert si.validate(Decimal128("12.42")) == Decimal128("12.42")
+
+    def test_input_str(self):
+        si = S.NumberDecimal(precision=2)
+        self.assertRaises(S.Invalid, si.validate, "12.42")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Closes #5 

- Adds support for `bson.Decimal128` values, with the `schema.NumberDecimal` field type. The name `NumberDecimal` comes from the js syntax in use on the mongo shell.
- Deprecates `_safe_bson` and `Object.make_safe`