### PR TITLE
Make the ODM before_save hook work on py3

### DIFF
--- a/ming/odm/declarative.py
+++ b/ming/odm/declarative.py
@@ -80,7 +80,7 @@ class _MappedClassMeta(type):
             migrate=getattr(mm, 'migrate', None)
         )
         if hasattr(mm, 'before_save'):
-            collection_kwargs['before_save'] = mm.before_save.__func__
+            collection_kwargs['before_save'] = getattr(mm.before_save, '__func__', mm.before_save)
         if not doc_bases:
             collection_cls = collection(
                 mm.name, mm.session and mm.session.impl,

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+# no envlist since .travis.yml specifies envs; maybe use tox-travis someday
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This follows the pattern used for non-ODM hooks: https://github.com/TurboGears/Ming/blob/433b94a2fe67a147ec43edde90228fe3705f2223/ming/declarative.py#L41-L44

After this is merged to master I'll backport to the 0.5.x branch too