### PR TITLE
Remove `as_class` param and arg ordering

### DIFF
--- a/ming/session.py
+++ b/ming/session.py
@@ -75,12 +75,9 @@ class Session(object):
         strip_extra = kwargs.pop('strip_extra', True)
         validate = kwargs.pop('validate', True)
 
-        projection = kwargs.pop('fields', kwargs.pop('projection', None))
+        projection = kwargs.pop('projection', None)
         if projection is not None:
             kwargs['projection'] = projection
-
-        if not validate:
-            kwargs['as_class'] = Object
 
         collection = self._impl(cls)
         cursor = collection.find(*args, **kwargs)

--- a/ming/tests/test_mim.py
+++ b/ming/tests/test_mim.py
@@ -98,8 +98,7 @@ class TestDatastore(TestCase):
         self.assertEqual(0, f(dict({'_id': 'bar', '$or': [{'a': 2}, {'c':{'$all':[1,2,3]}}]})).count())
         self.assertEqual(1, f(dict({'_id': 'foo', '$or': [{'a': 2}, {'c':{'$all':[1,2,3]}}]})).count())
 
-    def test_find_with_fields(self):
-        # I think this should be removed
+    def test_find_with_projection_list(self):
         o = self.bind.db.coll.find_one({'a': 2}, projection=['a'])
         assert o['a'] == 2
         assert o['_id'] == 'foo'

--- a/ming/tests/test_schema.py
+++ b/ming/tests/test_schema.py
@@ -27,6 +27,7 @@ class TestQuerySafety(TestCase):
     def test_extra_fields_stripped(self):
         r = self.Doc.m.find().all()
         assert  r == [ dict(a=2, _id='foo') ], r
+        assert 'Doc' in str(type(r[0]))
         r = self.Doc.m.find({}, allow_extra=True).all()
         assert  r == [ dict(a=2, _id='foo') ], r
         r = self.Doc.m.get(_id='foo')
@@ -39,6 +40,12 @@ class TestQuerySafety(TestCase):
     def test_extra_fields_not_allowed(self):
         q = self.Doc.m.find({}, allow_extra=False)
         self.assertRaises(S.Invalid, q.all)
+
+    def test_no_validate(self):
+        r = list(self.Doc.m.find({}, validate=False))
+        assert 'Doc' in str(type(r[0]))
+        assert r == [dict(_id='foo', a=2, b=3)], r
+
 
 class TestSchemaItem(TestCase):
 


### PR DESCRIPTION
Remove `as_class`, update `fields`/`projection` args, and update arg order, to match pymongo 3+ correctly

When validate=False was used on find() and a real mongo instance (not mim), it was erroring:
```
  File "/src/ming/ming/session.py", line 86, in find
    cursor = collection.find(*args, **kwargs)
  File "/var/local/env3-sfpy/lib/python3.7/site-packages/pymongo/collection.py", line 1460, in find
    return Cursor(self, *args, **kwargs)
Exception: __init__() got an unexpected keyword argument 'as_class'
```