### PR TITLE
Handle cursor iter when items are real items not mim pairs

### DIFF
--- a/ming/mim.py
+++ b/ming/mim.py
@@ -720,7 +720,9 @@ class Cursor(object):
     @LazyProperty
     def iterator(self):
         self._safe_to_chain = False
-        result = (doc for doc,match in self._iterator_gen())
+        # normally a (doc, match) tuple but could be a single doc (e.g. when gridfs indexes involved)
+        result = (doc_match[0] if isinstance(doc_match, tuple) else doc_match
+                  for doc_match in self._iterator_gen())
         if self._sort is not None:
             result = sorted(result, key=cmp_to_key(
                     cursor_comparator(self._sort)))

--- a/ming/tests/test_gridfs.py
+++ b/ming/tests/test_gridfs.py
@@ -27,8 +27,8 @@ class TestFS(TestCase):
     def setUp(self):
         self.ds = create_datastore('mim:///test')
         self.Session = Session(bind=self.ds)
-        self.TestFS = fs.filesystem(
-            'test_fs', self.Session)
+        self.fs_coll = 'test_fs'
+        self.TestFS = fs.filesystem(self.fs_coll, self.Session)
 
     def tearDown(self):
         self.ds.bind.drop_all()
@@ -97,4 +97,7 @@ class TestFS(TestCase):
             self.TestFS.m.get_version('test.txt', -1).read().decode(),
             'jumped over the lazy dog')
 
-
+    def test_custom_index(self):
+        self.ds.db['{}.files'.format(self.fs_coll)].ensure_index('custom_fld')
+        with self.TestFS.m.new_file('test.txt') as fp:
+            fp.write('The quick brown fox')


### PR DESCRIPTION
This is to fix errors like the following when using pymongo 3.5+ 

```
  vi +180  /Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py  # __create_index
    index_keys =[index_spec['key'] for index_spec in collection.list_indexes()]
  vi +180  /Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py  # <listcomp>
    index_keys =[index_spec['key'] for index_spec in collection.list_indexes()]
TypeError: string indices must be integers
```
or
```
  File "/Users/brondsem/sf/allura/Allura/allura/model/filesystem.py", line 95, in from_stream
    fp_w.write(s)
  File "/Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py", line 413, in __exit__
    self.close()
  File "/Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py", line 321, in close
    self.__flush()
  File "/Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py", line 297, in __flush
    self.__flush_buffer()
  File "/Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py", line 289, in __flush_buffer
    self.__flush_data(self._buffer.getvalue())
  File "/Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py", line 267, in __flush_data
    self.__ensure_indexes()
  File "/Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py", line 211, in __ensure_indexes
    self.__create_index(self._coll.chunks, _C_INDEX, True)
  File "/Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py", line 201, in __create_index
    collection.list_indexes(session=self._session)]
  File "/Users/brondsem/sf/env3-allura/lib/python3.7/site-packages/gridfs/grid_file.py", line 200, in <listcomp>
    index_keys = [index_spec['key'] for index_spec in
  File "/Users/brondsem/sf/ming/ming/mim.py", line 777, in next
    value = six.next(self.iterator)
  File "/Users/brondsem/sf/ming/ming/mim.py", line 725, in <genexpr>
    result = (doc for doc, match in self._iterator_gen())
ValueError: too many values to unpack (expected 2)
```
