### PR TITLE
Use our __insert not pymongo parent _insert

### DIFF
--- a/ming/mim.py
+++ b/ming/mim.py
@@ -495,7 +495,7 @@ class Collection(collection.Collection):
         warnings.warn('save is now deprecated, please use insert_one or replace_one', DeprecationWarning)
         _id = doc.get('_id', ())
         if _id == ():
-            return self._insert(doc)
+            return self.__insert(doc)
         else:
             self.__update({'_id':_id}, doc, upsert=True)
             return _id

--- a/ming/tests/test_mim.py
+++ b/ming/tests/test_mim.py
@@ -764,6 +764,15 @@ class TestCollection(TestCase):
             self.bind.db.coll.insert(doc, manipulate=True)
         self.assertEqual(doc, {'x': 1, '_id': sample_id})
 
+    def test_save_id(self):
+        doc = {'_id': bson.ObjectId(), 'x': 1}
+        self.bind.db.coll.save(doc)
+
+    def test_save_no_id(self):
+        doc = {'x': 1}
+        self.bind.db.coll.save(doc)
+        assert isinstance(doc['_id'], bson.ObjectId)
+
     def test_unique_index_subdocument(self):
         coll = self.bind.db.coll
 


### PR DESCRIPTION
Fixes cases where running `MyModel.m.save()` and `MyModel` doesn't have an `_id` field explicitly declared, so it is missing during initial save.