### PR TITLE
MIM: Avoid errors from _ensure_orig_key when positional $ is used

### DIFF
--- a/ming/mim.py
+++ b/ming/mim.py
@@ -1066,6 +1066,8 @@ class Match(object):
         doc = self
         for step in path[:-1]:
             if isinstance(doc, MatchList):
+                if step == '$':
+                    return
                 step = int(step)
             if step not in doc._orig:
                 doc._orig[step] = doc._doc[step]._orig

--- a/ming/tests/test_mim.py
+++ b/ming/tests/test_mim.py
@@ -191,6 +191,12 @@ class TestDottedOperators(TestCase):
         obj = self.coll.find_one({}, { '_id': 0, 'b.e': 1 })
         self.assertEqual(obj, { 'b': { 'e': [ 1,3,3 ] } })
 
+    def test_inc_dotted_dollar_middle1(self):
+        # match on g=1 and $inc by 10
+        self.coll.update({'b.f.g': 1}, { '$inc': { 'b.f.$.g': 10 } })
+        obj = self.coll.find_one({}, { '_id': 0, 'b.f': 1 })
+        self.assertEqual(obj, { 'b': { 'f': [ { 'g': 11 }, { 'g': 2 } ] }})
+
     def test_find_dotted(self):
         self.assertEqual(self.coll.find({'b.c': 1}).count(), 1)
         self.assertEqual(self.coll.find({'b.c': 2}).count(), 0)


### PR DESCRIPTION
There may well be a better way to do this, but this avoids an error from `_ensure_orig_key` when a [positional $](https://docs.mongodb.com/manual/reference/operator/update/positional/) is used in the middle of dotted notation.  (This test passes with earlier versions of ming before `_ensure_orig_key` was added)