### PR TITLE
handle rare race condition exception

### DIFF
--- a/ming/odm/odmsession.py
+++ b/ming/odm/odmsession.py
@@ -454,7 +454,13 @@ class ContextualODMSession(ContextualProxy):
     def close_all(cls, context):
         for sess in cls._session_registry[context].values():
             sess.close()
-        del cls._session_registry[context]
+        try:
+            del cls._session_registry[context]
+        except KeyError:
+            # since _session_registry is a defaultdict, we don't expect this to fail, but in a multithreaded
+            # environment it can.  Apparently if another thread deletes the entry in between this code accessing it
+            # with [] and deleting it with del, then a KeyError is raised.  So we ignore it
+            pass
 
 
 class ODMCursor:


### PR DESCRIPTION
fix this occasion error from being raised:
```
File '/var/local/env-sfpy/lib/python3.7/site-packages/ming/odm/middleware.py', line 31 in __call__
  self._cleanup_request()
File '/var/local/env-sfpy/lib/python3.7/site-packages/ming/odm/middleware.py', line 48 in _cleanup_request
  ContextualODMSession.close_all(context)
File '/var/local/env-sfpy/lib/python3.7/site-packages/ming/odm/odmsession.py', line 457 in close_all
  del cls._session_registry[context]
KeyError: None
```