### PR TITLE
MIM: add support for UUID types

### DIFF
--- a/ming/mim.py
+++ b/ming/mim.py
@@ -5,6 +5,7 @@ import re
 import sys
 import time
 import itertools
+import uuid
 from itertools import chain
 import collections
 import logging
@@ -885,6 +886,7 @@ class BsonArith:
     @classmethod
     def _build_types(cls):
         # this is a list of conversion functions, and the types they apply to
+        # see also bson._ENCODERS for what pymongo itself handles
         cls._types = [
             (lambda x:x, [type(None)]),
             (lambda x:x, [int]),
@@ -899,6 +901,7 @@ class BsonArith:
             (lambda x:x, [datetime]),
             (lambda x:x, [bson.Regex]),
             (lambda x:x, [float]),
+            (lambda x:x, [uuid.UUID]),
         ]
 
 

--- a/ming/tests/test_mim.py
+++ b/ming/tests/test_mim.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 from datetime import datetime
 from unittest import TestCase
 
@@ -1063,6 +1064,14 @@ class TestMatch(TestCase):
     def test_traverse_none(self):
         doc = {'a': None}
         self.assertIsNone(mim.match({'a.b.c': 1}, doc))
+
+    def test_uuid_match(self):
+        uu = uuid.UUID('{12345678-1234-5678-1234-567812345678}')
+        uu_same = uuid.UUID('{12345678-1234-5678-1234-567812345678}')
+        uu_diff = uuid.UUID('{12345678-1234-5678-1234-567812345670}')
+        doc = {'a': uu}
+        self.assertIsNotNone(mim.match({'a': uu_same}, doc))
+        self.assertIsNone(mim.match({'a': uu_diff}, doc))
 
 
 class TestBulkOperations(TestCase):


### PR DESCRIPTION
pymongo handles these automatically: https://pymongo.readthedocs.io/en/3.12.3/examples/uuid.html

This is helpful for encryption, since pymongo's `ClientEncryption.create_data_key` creates a doc with `_id` being a UUID