### PR TITLE
MIM: raise an error just like pymongo if find/find_one recieves unexpected kwargs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,9 +54,10 @@ jobs:
         run: tox --skip-missing-interpreters false -e py`echo ${{ matrix.python-version }} | sed s/\\\.// | sed s/pypy/py/ | sed s/-dev//`
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           flags: tests-${{ matrix.python-version }}
           name: codecov-umbrella
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/ming/tests/test_mim.py
+++ b/ming/tests/test_mim.py
@@ -150,6 +150,12 @@ class TestDatastore(TestCase):
         assert o['c'] == [1, 2, 3]
         assert o['score'] == 1.0  # MIM currently always reports 1 as the score.
 
+    def test_find_with_invalid_kwargs(self):
+        self.assertRaises(TypeError, self.bind.db.coll.find, foo=123)
+        self.assertRaises(TypeError, self.bind.db.coll.find, {'a': 2}, foo=123)
+        self.assertRaises(TypeError, self.bind.db.coll.find_one, foo=123)
+        self.bind.db.coll.find(allow_disk_use=True)  # kwargs that pymongo knows are ok
+
     def test_rewind(self):
         collection = self.bind.db.coll
         collection.insert({'a':'b'}, safe=True)


### PR DESCRIPTION
This will help prevent accidentally using kwargs, when you should use a dict