### PR TITLE
MIM: unique sparse deep indexes shouldn't auto-create fields

### DIFF
--- a/ming/mim.py
+++ b/ming/mim.py
@@ -1428,11 +1428,17 @@ def wrap_as_class(value, as_class):
         return value
 
 
-def _traverse_doc(doc, key):
+def _traverse_doc(doc: dict, key: str, auto_create_fields: bool = False):
     path = key.split('.')
     cur = doc
     for part in path[:-1]:
-        cur = cur.setdefault(part, {})
+        if part not in cur:
+            if auto_create_fields:
+                cur[part] = {}
+            else:
+                return {}, path[-1]
+
+        cur = cur[part]
     return cur, path[-1]
 
 
@@ -1489,7 +1495,7 @@ class Projection:
                         raise ValueError('Unsupported projection operator %s' % projection_op)
 
             sub_doc, key = _traverse_doc(doc, name)
-            sub_result, key = _traverse_doc(result, name)
+            sub_result, key = _traverse_doc(result, name, auto_create_fields=True)
             try:
                 sub_result[key] = sub_doc[key]
             except KeyError:

--- a/ming/tests/test_mim.py
+++ b/ming/tests/test_mim.py
@@ -663,8 +663,14 @@ class TestCollection(TestCase):
         coll.insert_one({'x': {'y': None}})
         coll.insert_one({'x': {'other': 'field'}})
         coll.insert_one({'x': {'other': 'field'}})
+
         # still errors on an existing duplication
         self.assertRaises(DuplicateKeyError, coll.insert_one, {'x': {'y': 1}})
+
+        # 'x' or 'x.y' field should not get auto-created
+        coll.insert_one({'not-x': 123})
+        doc = coll.find_one({'not-x': 123})
+        assert set(doc.keys()) == {'_id', 'not-x'}
 
     def test_unique_sparse_index_whole_sdoc(self):
         coll = self.bind.db.coll


### PR DESCRIPTION
MIM: unique sparse deep indexes should not auto-create any parts of the deep field name

Auto-creation while traversing deep paths is only needed when "projecting" fields in a result output doc